### PR TITLE
feat: Implement Phase 1 Ride-Hailing API with Auth

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -1,0 +1,66 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow lets you generate SLSA provenance file for your project.
+# The generation satisfies level 3 for the provenance requirements - see https://slsa.dev/spec/v0.1/requirements
+# The project is an initiative of the OpenSSF (openssf.org) and is developed at
+# https://github.com/slsa-framework/slsa-github-generator.
+# The provenance file can be verified using https://github.com/slsa-framework/slsa-verifier.
+# For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
+
+name: SLSA generic generator
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      digests: ${{ steps.hash.outputs.digests }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ========================================================
+      #
+      # Step 1: Build your artifacts.
+      #
+      # ========================================================
+      - name: Build artifacts
+        run: |
+            # These are some amazing artifacts.
+            echo "artifact1" > artifact1
+            echo "artifact2" > artifact2
+
+      # ========================================================
+      #
+      # Step 2: Add a step to generate the provenance subjects
+      #         as shown below. Update the sha256 sum arguments
+      #         to include all binaries that you generate
+      #         provenance for.
+      #
+      # ========================================================
+      - name: Generate subject for provenance
+        id: hash
+        run: |
+          set -euo pipefail
+
+          # List the artifacts the provenance will refer to.
+          files=$(ls artifact*)
+          # Generate the subjects (base64 encoded).
+          echo "hashes=$(sha256sum $files | base64 -w0)" >> "${GITHUB_OUTPUT}"
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read   # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.digests }}"
+      upload-assets: true # Optional: Upload to a new release

--- a/packnride_api/.env.example
+++ b/packnride_api/.env.example
@@ -1,0 +1,7 @@
+# .env.example - Rename to .env and fill in your actual values
+# Flask settings
+SECRET_KEY=a_very_strong_random_secret_key_for_flask_sessions
+FLASK_ENV=development # or production, testing
+
+# JWT Settings
+JWT_SECRET_KEY=another_very_strong_random_secret_key_for_jwt

--- a/packnride_api/README.md
+++ b/packnride_api/README.md
@@ -1,6 +1,6 @@
-# PacknRide API (Flask Backend - Phase 1)
+# PacknRide API (Flask Backend)
 
-This is a simple Flask-based backend API for the PacknRide application, focusing on User Authentication and core Ride-Hailing features. This version uses in-memory data storage for simplicity.
+This is a Flask-based backend API for the PacknRide application. It includes User Authentication, core Ride-Hailing features, and a Driving Monitoring Portal. This version uses in-memory data storage for simplicity.
 
 ## Project Structure
 
@@ -10,8 +10,14 @@ packnride_api/
 │   ├── __init__.py       # Application factory, initializes Flask app & extensions
 │   ├── auth.py           # Authentication routes (register, login)
 │   ├── models.py         # Data models (currently conceptual for in-memory store)
-│   ├── routes.py         # Main API routes (rides, drivers)
+│   ├── routes.py         # Main API routes for ride-hailing
+│   ├── monitoring_routes.py # API routes for Driving Monitoring Portal
 │   └── utils.py          # Utility functions (e.g., password hashing)
+├── tests/                # Pytest tests
+│   ├── conftest.py       # Pytest fixtures
+│   ├── test_auth.py      # Tests for authentication
+│   ├── test_rides.py     # Tests for ride-hailing
+│   └── test_monitoring.py # Tests for monitoring portal
 ├── config.py             # Configuration classes (Dev, Prod, Test)
 ├── run.py                # Script to run the Flask development server
 ├── requirements.txt      # Python dependencies
@@ -30,6 +36,7 @@ packnride_api/
     ```bash
     pip install -r requirements.txt
     ```
+    *(Note: If `pip install` fails due to `getcwd` errors in certain sandboxed environments, manual setup of dependencies might be needed, or testing in a different environment.)*
 4.  **Set up environment variables:**
     *   Rename `.env.example` to `.env`.
     *   Fill in the required values in `.env`, especially `SECRET_KEY` and `JWT_SECRET_KEY`.
@@ -43,13 +50,22 @@ packnride_api/
     ```bash
     python run.py
     ```
-    The API should now be running on `http://0.0.0.0:5000`. You will see output like:
-    `Starting PacknRide API on 0.0.0.0:5000 with config: development`
+    The API should now be running on `http://0.0.0.0:5000`.
+
+6.  **Running Tests (Recommended in a standard environment):**
+    ```bash
+    # Ensure dependencies including pytest and pytest-flask are installed
+    # From the packnride_api directory:
+    PYTHONPATH=. pytest tests/ -v
+    ```
+    *(Note: Test execution might fail in some sandboxed environments due to `getcwd` errors.)*
+
 
 ## API Endpoints
 
-All main API routes are prefixed with `/api`, and authentication routes with `/auth`.
+All main API routes are prefixed with `/api`, authentication routes with `/auth`, and monitoring routes with `/api/monitoring`.
 A JWT access token is required for protected endpoints (indicated by `🔒`). Send the token in the `Authorization` header as `Bearer <token>`.
+Admin access is typically required for monitoring endpoints and is controlled by an `is_admin` claim in the JWT.
 
 ---
 
@@ -57,10 +73,7 @@ A JWT access token is required for protected endpoints (indicated by `🔒`). Se
 
 *   **GET /health**
     *   Description: Checks if the API is running.
-    *   Response: `200 OK`
-        ```json
-        "PacknRide API is healthy!"
-        ```
+    *   Response: `200 OK` - `"PacknRide API is healthy!"`
 
 ---
 
@@ -74,188 +87,134 @@ A JWT access token is required for protected endpoints (indicated by `🔒`). Se
             "name": "Test User",
             "email": "user@example.com",
             "password": "password123",
-            "user_type": "passenger" // or "driver"
+            "user_type": "passenger", // or "driver"
+            "is_admin": false // optional, defaults to false
         }
         ```
-    *   Response: `201 Created`
-        ```json
-        {
-            "message": "User registered successfully",
-            "user": {
-                "id": 1,
-                "name": "Test User",
-                "email": "user@example.com",
-                "user_type": "passenger"
-            }
-        }
-        ```
-    *   Error Responses: `400 Bad Request` (missing fields, invalid user_type), `409 Conflict` (email exists).
+    *   Response: `201 Created` (user object including `is_admin` status)
+    *   Error Responses: `400 Bad Request`, `409 Conflict`.
 
 2.  **POST /auth/login**
     *   Description: Logs in an existing user.
-    *   Request Body:
-        ```json
-        {
-            "email": "user@example.com",
-            "password": "password123"
-        }
-        ```
-    *   Response: `200 OK`
-        ```json
-        {
-            "access_token": "your_jwt_access_token_here"
-        }
-        ```
-    *   Error Responses: `400 Bad Request` (missing fields), `401 Unauthorized` (invalid credentials), `404 Not Found` (email not found).
+    *   Request Body: (email, password)
+    *   Response: `200 OK` (`{"access_token": "..."}`)
+    *   Error Responses: `400 Bad Request`, `401 Unauthorized`, `404 Not Found`.
 
 ---
 
 ### Rides (`/api/rides`)
 
-1.  **POST /api/rides/request** 🔒
-    *   Description: Allows an authenticated 'passenger' to request a new ride.
-    *   Request Body:
-        ```json
-        {
-            "pickup_location": "123 Main St",
-            "dropoff_location": "789 Oak Ave"
-        }
-        ```
-    *   Response: `201 Created` (example)
-        ```json
-        {
-            "message": "Ride requested successfully",
-            "ride": {
-                "id": 1,
-                "passenger_id": 1,
-                "driver_id": null,
-                "pickup_location": "123 Main St",
-                "dropoff_location": "789 Oak Ave",
-                "status": "pending",
-                "fare": null,
-                "requested_at": "2023-10-27T10:00:00Z",
-                "updated_at": "2023-10-27T10:00:00Z"
-            }
-        }
-        ```
-    *   Error Responses: `400 Bad Request`, `401 Unauthorized`, `403 Forbidden` (if not a passenger).
+1.  **POST /api/rides/request** 🔒 (Passenger)
+    *   Request: `{"pickup_location": "...", "dropoff_location": "..."}`
+    *   Response: `201 Created` (ride object)
 
-2.  **GET /api/rides/<ride_id>** 🔒
-    *   Description: Retrieves details for a specific ride. Accessible by the passenger who requested or the assigned driver.
-    *   Response: `200 OK` (example)
-        ```json
-        {
-            "id": 1,
-            "passenger_id": 1,
-            "driver_id": 2,
-            "pickup_location": "123 Main St",
-            "dropoff_location": "789 Oak Ave",
-            "status": "accepted",
-            "fare": null,
-            "requested_at": "2023-10-27T10:00:00Z",
-            "updated_at": "2023-10-27T10:05:00Z"
-        }
-        ```
-    *   Error Responses: `401 Unauthorized`, `403 Forbidden`, `404 Not Found`.
+2.  **GET /api/rides/<ride_id>** 🔒 (Passenger or assigned Driver)
+    *   Response: `200 OK` (ride object)
 
-3.  **POST /api/rides/<ride_id>/accept** 🔒
-    *   Description: Allows an authenticated 'driver' to accept a pending ride.
-    *   Response: `200 OK` (example)
-        ```json
-        {
-            "message": "Ride accepted successfully",
-            "ride": {
-                "id": 1,
-                "passenger_id": 1,
-                "driver_id": 2, // Driver's ID
-                "pickup_location": "123 Main St",
-                "dropoff_location": "789 Oak Ave",
-                "status": "accepted",
-                "fare": null,
-                // ... timestamps
-            }
-        }
-        ```
-    *   Error Responses: `400 Bad Request` (ride not pending), `401 Unauthorized`, `403 Forbidden` (if not a driver), `404 Not Found`, `409 Conflict` (already accepted).
+3.  **POST /api/rides/<ride_id>/accept** 🔒 (Driver)
+    *   Response: `200 OK` (updated ride object)
 
-4.  **PUT /api/rides/<ride_id>/status** 🔒
-    *   Description: Allows the authenticated passenger or driver to update the ride status.
-    *   Valid statuses: `en_route_pickup`, `arrived_pickup`, `started`, `completed`, `cancelled`.
-    *   Request Body:
-        ```json
-        {
-            "status": "en_route_pickup"
-        }
-        ```
-    *   Response: `200 OK` (example)
-        ```json
-        {
-            "message": "Ride status updated to en_route_pickup",
-            "ride": {
-                // ... updated ride object
-                "status": "en_route_pickup"
-            }
-        }
-        ```
-    *   Error Responses: `400 Bad Request` (invalid status), `401 Unauthorized`, `403 Forbidden` (invalid transition or not authorized), `404 Not Found`.
+4.  **PUT /api/rides/<ride_id>/status** 🔒 (Passenger or assigned Driver, rules apply)
+    *   Request: `{"status": "new_status"}` (e.g., "en_route_pickup", "completed", "cancelled")
+    *   Response: `200 OK` (updated ride object)
 
-5.  **POST /api/rides/estimate_fare** 🔒
-    *   Description: (Mocked) Provides a mock fare estimation.
-    *   Request Body:
-        ```json
-        {
-            "pickup_location": "Point A",
-            "dropoff_location": "Point B"
-        }
-        ```
-    *   Response: `200 OK` (example)
-        ```json
-        {
-            "pickup_location": "Point A",
-            "dropoff_location": "Point B",
-            "estimated_fare_rand": "R25.50",
-            "currency": "ZAR",
-            "note": "This is a mock estimation. Actual fare may vary."
-        }
-        ```
-    *   Error Responses: `400 Bad Request`, `401 Unauthorized`.
+5.  **POST /api/rides/estimate_fare** 🔒 (Mocked)
+    *   Request: `{"pickup_location": "...", "dropoff_location": "..."}`
+    *   Response: `200 OK` (mocked fare estimation)
 
 ---
 
 ### Drivers (`/api/drivers`)
 
-1.  **GET /api/drivers/nearby** 🔒
-    *   Description: (Mocked) Allows an authenticated 'passenger' to get a list of supposedly available drivers.
-    *   Response: `200 OK` (example)
+1.  **GET /api/drivers/nearby** 🔒 (Passenger, Mocked)
+    *   Response: `200 OK` (list of available drivers)
+
+---
+
+### Driving Monitoring Portal (`/api/monitoring`)
+
+1.  **POST /api/monitoring/events** 🔒 (Admin or Self-Driver)
+    *   Description: Logs a new driving event (e.g., speeding, harsh braking).
+    *   Request Body:
         ```json
         {
-            "available_drivers": [
-                {
-                    "id": 2,
-                    "name": "Driver One",
-                    "mock_location": "Nearby Location 42",
-                    "vehicle_type": "Sedan",
-                    "current_status": "available"
-                }
-                // ... other drivers
-            ]
+            "driver_id": 1,
+            "ride_id": 101, // optional
+            "event_type": "speeding",
+            "timestamp": "2023-11-15T10:30:00Z",
+            "location_lat": -25.7479,
+            "location_lon": 28.2293,
+            "details": {"speed_kmh": 120, "limit_kmh": 80}
         }
         ```
-    *   Error Responses: `401 Unauthorized`, `403 Forbidden` (if not a passenger).
+    *   Response: `201 Created` (event object)
+
+2.  **GET /api/monitoring/drivers/<driver_id>/events** 🔒 (Admin or Self-Driver)
+    *   Description: Retrieves driving events for a specific driver.
+    *   Query Params: `event_type` (optional)
+    *   Response: `200 OK` (`{"driver_id": X, "events": [...]}`)
+
+3.  **GET /api/monitoring/drivers/<driver_id>/score** 🔒 (Admin or Self-Driver)
+    *   Description: Retrieves the performance score for a driver.
+    *   Response: `200 OK` (score object, or default if none exists)
+
+4.  **PUT /api/monitoring/drivers/<driver_id>/score** 🔒 (Admin only)
+    *   Description: Manually updates a driver's performance score.
+    *   Request Body:
+        ```json
+        {
+            "overall_safety_score": 85, // 0-100
+            "efficiency_score": 90,   // 0-100
+            "punctuality_score": 75,  // 0-100
+            "feedback_summary": "Generally good, watch speed on Main St."
+        }
+        ```
+    *   Response: `200 OK` (updated score object)
+
+5.  **POST /api/monitoring/incidents** 🔒 (Admin only)
+    *   Description: Logs a new incident report.
+    *   Request Body:
+        ```json
+        {
+            "driver_id": 1,
+            "ride_id": 102, // optional
+            "incident_type": "minor_accident",
+            "description": "Minor collision, no injuries.",
+            "status": "open" // 'open', 'investigating', 'resolved', 'closed'
+        }
+        ```
+    *   Response: `201 Created` (incident report object)
+
+6.  **GET /api/monitoring/incidents** 🔒 (Admin only)
+    *   Description: Retrieves a list of all incidents.
+    *   Query Params: `driver_id`, `status` (optional)
+    *   Response: `200 OK` (`{"incidents": [...]}`)
+
+7.  **GET /api/monitoring/incidents/<report_id>** 🔒 (Admin only)
+    *   Description: Retrieves details of a specific incident.
+    *   Response: `200 OK` (incident report object)
+
+8.  **PUT /api/monitoring/incidents/<report_id>** 🔒 (Admin only)
+    *   Description: Updates an incident report.
+    *   Request Body:
+        ```json
+        {
+            "status": "resolved",
+            "resolution_notes": "Driver cautioned, passenger compensated."
+        }
+        ```
+    *   Response: `200 OK` (updated incident report object)
 
 ---
 
 ## Future Considerations (Not Implemented)
 
-*   Database integration (e.g., PostgreSQL, MongoDB with an ORM/ODM like SQLAlchemy or MongoEngine).
-*   Real-time GPS tracking (e.g., WebSockets, GeoJSON).
-*   Actual fare calculation logic.
-*   Driver availability management.
-*   Push notifications.
-*   More sophisticated error handling and logging.
-*   Testing suite.
-*   Food Delivery, Courier, Admin Portal modules.
+*   Database integration (e.g., PostgreSQL, MongoDB).
+*   Real-time GPS data ingestion for events.
+*   Automated calculation of driver scores from events.
+*   Advanced filtering and reporting for monitoring.
+*   Push notifications for critical alerts.
+*   More sophisticated Role-Based Access Control (RBAC).
+*   Dedicated frontends for Admin Portal and User Apps.
+*   Modules for Food Delivery, Courier Services.
 ```
-
-This README provides a good overview for someone looking to understand or run this Phase 1 API.
-I'll verify the file creation.

--- a/packnride_api/README.md
+++ b/packnride_api/README.md
@@ -1,0 +1,261 @@
+# PacknRide API (Flask Backend - Phase 1)
+
+This is a simple Flask-based backend API for the PacknRide application, focusing on User Authentication and core Ride-Hailing features. This version uses in-memory data storage for simplicity.
+
+## Project Structure
+
+```
+packnride_api/
+├── app/                  # Main application package
+│   ├── __init__.py       # Application factory, initializes Flask app & extensions
+│   ├── auth.py           # Authentication routes (register, login)
+│   ├── models.py         # Data models (currently conceptual for in-memory store)
+│   ├── routes.py         # Main API routes (rides, drivers)
+│   └── utils.py          # Utility functions (e.g., password hashing)
+├── config.py             # Configuration classes (Dev, Prod, Test)
+├── run.py                # Script to run the Flask development server
+├── requirements.txt      # Python dependencies
+└── .env.example          # Example environment variables
+```
+
+## Setup and Running
+
+1.  **Clone the repository (if applicable) or ensure you have the files.**
+2.  **Create a virtual environment (recommended):**
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    ```
+3.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+4.  **Set up environment variables:**
+    *   Rename `.env.example` to `.env`.
+    *   Fill in the required values in `.env`, especially `SECRET_KEY` and `JWT_SECRET_KEY`.
+    ```env
+    # .env
+    SECRET_KEY=your_flask_secret_key_here
+    JWT_SECRET_KEY=your_jwt_secret_key_here
+    FLASK_ENV=development
+    ```
+5.  **Run the application:**
+    ```bash
+    python run.py
+    ```
+    The API should now be running on `http://0.0.0.0:5000`. You will see output like:
+    `Starting PacknRide API on 0.0.0.0:5000 with config: development`
+
+## API Endpoints
+
+All main API routes are prefixed with `/api`, and authentication routes with `/auth`.
+A JWT access token is required for protected endpoints (indicated by `🔒`). Send the token in the `Authorization` header as `Bearer <token>`.
+
+---
+
+### Health Check
+
+*   **GET /health**
+    *   Description: Checks if the API is running.
+    *   Response: `200 OK`
+        ```json
+        "PacknRide API is healthy!"
+        ```
+
+---
+
+### Authentication (`/auth`)
+
+1.  **POST /auth/register**
+    *   Description: Registers a new user.
+    *   Request Body:
+        ```json
+        {
+            "name": "Test User",
+            "email": "user@example.com",
+            "password": "password123",
+            "user_type": "passenger" // or "driver"
+        }
+        ```
+    *   Response: `201 Created`
+        ```json
+        {
+            "message": "User registered successfully",
+            "user": {
+                "id": 1,
+                "name": "Test User",
+                "email": "user@example.com",
+                "user_type": "passenger"
+            }
+        }
+        ```
+    *   Error Responses: `400 Bad Request` (missing fields, invalid user_type), `409 Conflict` (email exists).
+
+2.  **POST /auth/login**
+    *   Description: Logs in an existing user.
+    *   Request Body:
+        ```json
+        {
+            "email": "user@example.com",
+            "password": "password123"
+        }
+        ```
+    *   Response: `200 OK`
+        ```json
+        {
+            "access_token": "your_jwt_access_token_here"
+        }
+        ```
+    *   Error Responses: `400 Bad Request` (missing fields), `401 Unauthorized` (invalid credentials), `404 Not Found` (email not found).
+
+---
+
+### Rides (`/api/rides`)
+
+1.  **POST /api/rides/request** 🔒
+    *   Description: Allows an authenticated 'passenger' to request a new ride.
+    *   Request Body:
+        ```json
+        {
+            "pickup_location": "123 Main St",
+            "dropoff_location": "789 Oak Ave"
+        }
+        ```
+    *   Response: `201 Created` (example)
+        ```json
+        {
+            "message": "Ride requested successfully",
+            "ride": {
+                "id": 1,
+                "passenger_id": 1,
+                "driver_id": null,
+                "pickup_location": "123 Main St",
+                "dropoff_location": "789 Oak Ave",
+                "status": "pending",
+                "fare": null,
+                "requested_at": "2023-10-27T10:00:00Z",
+                "updated_at": "2023-10-27T10:00:00Z"
+            }
+        }
+        ```
+    *   Error Responses: `400 Bad Request`, `401 Unauthorized`, `403 Forbidden` (if not a passenger).
+
+2.  **GET /api/rides/<ride_id>** 🔒
+    *   Description: Retrieves details for a specific ride. Accessible by the passenger who requested or the assigned driver.
+    *   Response: `200 OK` (example)
+        ```json
+        {
+            "id": 1,
+            "passenger_id": 1,
+            "driver_id": 2,
+            "pickup_location": "123 Main St",
+            "dropoff_location": "789 Oak Ave",
+            "status": "accepted",
+            "fare": null,
+            "requested_at": "2023-10-27T10:00:00Z",
+            "updated_at": "2023-10-27T10:05:00Z"
+        }
+        ```
+    *   Error Responses: `401 Unauthorized`, `403 Forbidden`, `404 Not Found`.
+
+3.  **POST /api/rides/<ride_id>/accept** 🔒
+    *   Description: Allows an authenticated 'driver' to accept a pending ride.
+    *   Response: `200 OK` (example)
+        ```json
+        {
+            "message": "Ride accepted successfully",
+            "ride": {
+                "id": 1,
+                "passenger_id": 1,
+                "driver_id": 2, // Driver's ID
+                "pickup_location": "123 Main St",
+                "dropoff_location": "789 Oak Ave",
+                "status": "accepted",
+                "fare": null,
+                // ... timestamps
+            }
+        }
+        ```
+    *   Error Responses: `400 Bad Request` (ride not pending), `401 Unauthorized`, `403 Forbidden` (if not a driver), `404 Not Found`, `409 Conflict` (already accepted).
+
+4.  **PUT /api/rides/<ride_id>/status** 🔒
+    *   Description: Allows the authenticated passenger or driver to update the ride status.
+    *   Valid statuses: `en_route_pickup`, `arrived_pickup`, `started`, `completed`, `cancelled`.
+    *   Request Body:
+        ```json
+        {
+            "status": "en_route_pickup"
+        }
+        ```
+    *   Response: `200 OK` (example)
+        ```json
+        {
+            "message": "Ride status updated to en_route_pickup",
+            "ride": {
+                // ... updated ride object
+                "status": "en_route_pickup"
+            }
+        }
+        ```
+    *   Error Responses: `400 Bad Request` (invalid status), `401 Unauthorized`, `403 Forbidden` (invalid transition or not authorized), `404 Not Found`.
+
+5.  **POST /api/rides/estimate_fare** 🔒
+    *   Description: (Mocked) Provides a mock fare estimation.
+    *   Request Body:
+        ```json
+        {
+            "pickup_location": "Point A",
+            "dropoff_location": "Point B"
+        }
+        ```
+    *   Response: `200 OK` (example)
+        ```json
+        {
+            "pickup_location": "Point A",
+            "dropoff_location": "Point B",
+            "estimated_fare_rand": "R25.50",
+            "currency": "ZAR",
+            "note": "This is a mock estimation. Actual fare may vary."
+        }
+        ```
+    *   Error Responses: `400 Bad Request`, `401 Unauthorized`.
+
+---
+
+### Drivers (`/api/drivers`)
+
+1.  **GET /api/drivers/nearby** 🔒
+    *   Description: (Mocked) Allows an authenticated 'passenger' to get a list of supposedly available drivers.
+    *   Response: `200 OK` (example)
+        ```json
+        {
+            "available_drivers": [
+                {
+                    "id": 2,
+                    "name": "Driver One",
+                    "mock_location": "Nearby Location 42",
+                    "vehicle_type": "Sedan",
+                    "current_status": "available"
+                }
+                // ... other drivers
+            ]
+        }
+        ```
+    *   Error Responses: `401 Unauthorized`, `403 Forbidden` (if not a passenger).
+
+---
+
+## Future Considerations (Not Implemented)
+
+*   Database integration (e.g., PostgreSQL, MongoDB with an ORM/ODM like SQLAlchemy or MongoEngine).
+*   Real-time GPS tracking (e.g., WebSockets, GeoJSON).
+*   Actual fare calculation logic.
+*   Driver availability management.
+*   Push notifications.
+*   More sophisticated error handling and logging.
+*   Testing suite.
+*   Food Delivery, Courier, Admin Portal modules.
+```
+
+This README provides a good overview for someone looking to understand or run this Phase 1 API.
+I'll verify the file creation.

--- a/packnride_api/app/__init__.py
+++ b/packnride_api/app/__init__.py
@@ -1,0 +1,65 @@
+from flask import Flask
+from flask_jwt_extended import JWTManager
+from ..config import app_config
+
+# In-memory 'database' for simplicity
+users_db = {}  # Store user data: {email: user_object}
+rides_db = {}  # Store ride data: {ride_id: ride_object}
+
+# Class to manage ID generation for in-memory store
+class IDManager:
+    def __init__(self):
+        self.user_id_counter = 0
+        self.ride_id_counter = 0
+
+    def get_next_user_id(self):
+        self.user_id_counter += 1
+        return self.user_id_counter
+
+    def get_next_ride_id(self):
+        self.ride_id_counter += 1
+        return self.ride_id_counter
+
+id_manager = IDManager()
+
+jwt = JWTManager()
+
+def create_app(config_object=app_config):
+    """
+    Application factory pattern: creates and configures the Flask app.
+    """
+    app = Flask(__name__)
+    app.config.from_object(config_object)
+
+    # Initialize extensions
+    jwt.init_app(app)
+
+    # Register Blueprints
+    from .auth import auth_bp
+    from .routes import main_bp
+
+    app.register_blueprint(auth_bp, url_prefix='/auth')
+    app.register_blueprint(main_bp, url_prefix='/api')
+
+    @app.route('/health')
+    def health_check():
+        return "PacknRide API is healthy!", 200
+
+    # Callback for defining user identity from JWT
+    @jwt.user_identity_loader
+    def user_identity_lookup(user_identity):
+        return user_identity # The identity is already a dict from create_access_token
+
+    # Optional: Callback for loading user object from identity (if needed by @jwt_required)
+    # For simple cases where identity is enough, this isn't strictly necessary
+    # but good practice if you need to load the full user object often.
+    # @jwt.user_lookup_loader
+    # def user_lookup_callback(_jwt_header, jwt_data):
+    #     identity = jwt_data["sub"] # 'sub' is the key for identity in jwt_data
+    #     user_email = identity.get("email")
+    #     if user_email and user_email in users_db:
+    #         return users_db[user_email]
+    #     return None
+
+
+    return app

--- a/packnride_api/app/auth.py
+++ b/packnride_api/app/auth.py
@@ -1,0 +1,84 @@
+from flask import Blueprint, request, jsonify
+from app import users_db # Import users_db directly
+# We will need a better way to manage user_id_counter from app.__init__
+from app.utils import hash_password, verify_password
+from flask_jwt_extended import create_access_token
+import datetime # For potential token expiry, though not explicitly set in create_access_token default
+# Import the id_manager from app.__init__
+from app import id_manager
+
+
+auth_bp = Blueprint('auth_bp', __name__)
+
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid input, JSON required"}), 400
+
+    name = data.get('name')
+    email = data.get('email')
+    password = data.get('password')
+    user_type = data.get('user_type', 'passenger') # Default to passenger
+
+    if not email or not password or not name:
+        return jsonify({"error": "Missing name, email, or password"}), 400
+
+    if user_type not in ['passenger', 'driver']:
+        return jsonify({"error": "Invalid user_type. Must be 'passenger' or 'driver'"}), 400
+
+    if email in users_db:
+        return jsonify({"error": "Email already registered"}), 409 # 409 Conflict
+
+    current_id = id_manager.get_next_user_id()
+    hashed_pass = hash_password(password)
+
+    # User object structure
+    user_obj = {
+        "id": current_id,
+        "name": name,
+        "email": email,
+        "password_hash": hashed_pass,
+        "user_type": user_type,
+        "registered_on": datetime.datetime.utcnow().isoformat()
+    }
+    users_db[email] = user_obj # Use email as key for quick lookup
+
+    return jsonify({
+        "message": "User registered successfully",
+        "user": {"id": user_obj["id"], "name": name, "email": email, "user_type": user_type}
+    }), 201
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid input, JSON required"}), 400
+
+    email = data.get('email')
+    password = data.get('password')
+
+    if not email or not password:
+        return jsonify({"error": "Missing email or password"}), 400
+
+    user = users_db.get(email) # users_db is keyed by email
+    if not user:
+        return jsonify({"error": "Email not found"}), 404
+
+    if not verify_password(password, user['password_hash']):
+        return jsonify({"error": "Invalid credentials"}), 401
+
+    # Identity for the token can be user_id or email, or a more complex object
+    # Using a dictionary for identity is flexible.
+    identity_data = {"id": user["id"], "email": user["email"], "user_type": user["user_type"]}
+    access_token = create_access_token(identity=identity_data)
+    return jsonify(access_token=access_token), 200
+
+# Example of a protected route (optional, for testing)
+# from flask_jwt_extended import jwt_required, get_jwt_identity
+# @auth_bp.route('/protected', methods=['GET'])
+# @jwt_required()
+# def protected():
+#     current_user = get_jwt_identity()
+#     return jsonify(logged_in_as=current_user), 200

--- a/packnride_api/app/models.py
+++ b/packnride_api/app/models.py
@@ -1,0 +1,35 @@
+# For now, our models are implicitly handled by the in-memory dictionaries
+# in __init__.py (users_db, rides_db) and how we structure that data.
+# As the application grows, we would define classes here, especially
+# if using an ORM like SQLAlchemy.
+
+# Example of how a User class might look if we were using classes more formally
+# for the in-memory store or with an ORM:
+
+# class User:
+#     def __init__(self, id, name, email, password_hash, user_type):
+#         self.id = id
+#         self.name = name
+#         self.email = email
+#         self.password_hash = password_hash
+#         self.user_type = user_type # 'passenger' or 'driver'
+
+#     def __repr__(self):
+#         return f"<User {self.email}>"
+
+# class Ride:
+#     def __init__(self, id, passenger_id, pickup_location, dropoff_location, status="pending", driver_id=None, fare=None):
+#         self.id = id
+#         self.passenger_id = passenger_id
+#         self.driver_id = driver_id
+#         self.pickup_location = pickup_location
+#         self.dropoff_location = dropoff_location
+#         self.status = status # e.g., 'pending', 'accepted', 'started', 'completed', 'cancelled'
+#         self.fare = fare
+
+#     def __repr__(self):
+#         return f"<Ride {self.id} - {self.status}>"
+
+# We will define the structure of user and ride objects directly when we interact
+# with users_db and rides_db in routes.py and auth.py for now.
+pass

--- a/packnride_api/app/monitoring_routes.py
+++ b/packnride_api/app/monitoring_routes.py
@@ -1,0 +1,274 @@
+from flask import Blueprint, request, jsonify
+from app import driving_events_db, users_db, id_manager, driver_scores_db, incident_reports_db # Added incident_reports_db
+from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt
+import datetime
+
+monitoring_bp = Blueprint('monitoring_bp', __name__)
+
+# Helper function to check for admin privileges from JWT
+def is_admin_user():
+    claims = get_jwt()
+    return claims.get("is_admin", False)
+
+# --- Driving Event Endpoints ---
+@monitoring_bp.route('/events', methods=['POST'])
+@jwt_required()
+def log_driving_event():
+    current_user_identity = get_jwt_identity()
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid input, JSON required"}), 400
+
+    required_fields = ['driver_id', 'event_type', 'timestamp', 'location_lat', 'location_lon']
+    for field in required_fields:
+        if field not in data:
+            return jsonify({"error": f"Missing required field: {field}"}), 400
+
+    driver_id = data.get('driver_id')
+    event_type = data.get('event_type')
+    ride_id = data.get('ride_id')
+    details = data.get('details', {})
+
+    target_driver_exists = any(u['id'] == driver_id and u['user_type'] == 'driver' for u in users_db.values())
+    if not target_driver_exists:
+        return jsonify({"error": f"Driver with id {driver_id} not found."}), 404
+
+    is_current_user_the_driver = (current_user_identity.get('user_type') == 'driver' and
+                                  current_user_identity.get('id') == driver_id)
+
+    if not is_admin_user() and not is_current_user_the_driver:
+        return jsonify({"error": "Unauthorized to log event for this driver."}), 403
+
+    event_id = id_manager.get_next_driving_event_id()
+    event_obj = {
+        "event_id": event_id, "driver_id": driver_id, "ride_id": ride_id,
+        "event_type": event_type, "timestamp": data.get('timestamp'),
+        "location_lat": data.get('location_lat'), "location_lon": data.get('location_lon'),
+        "details": details, "logged_at": datetime.datetime.utcnow().isoformat()
+    }
+    driving_events_db[event_id] = event_obj
+    return jsonify({"message": "Driving event logged successfully", "event": event_obj}), 201
+
+
+@monitoring_bp.route('/drivers/<int:driver_id>/events', methods=['GET'])
+@jwt_required()
+def get_driver_events(driver_id):
+    current_user_identity = get_jwt_identity()
+    is_current_user_the_driver = (current_user_identity.get('user_type') == 'driver' and
+                                  current_user_identity.get('id') == driver_id)
+
+    if not is_admin_user() and not is_current_user_the_driver:
+        return jsonify({"error": "Unauthorized. Admin access or viewing own data required."}), 403
+
+    target_driver_exists = any(u['id'] == driver_id and u['user_type'] == 'driver' for u in users_db.values())
+    if not target_driver_exists:
+        return jsonify({"error": f"Driver with id {driver_id} not found."}), 404
+
+    event_type_filter = request.args.get('event_type')
+    driver_events = []
+    for _event_id, event in driving_events_db.items(): # Corrected variable name
+        if event['driver_id'] == driver_id:
+            if event_type_filter and event['event_type'] != event_type_filter:
+                continue
+            driver_events.append(event)
+
+    driver_events.sort(key=lambda x: x.get('timestamp', ''), reverse=True)
+    return jsonify({"driver_id": driver_id, "events": driver_events}), 200
+
+# --- Driver Performance Score Endpoints ---
+@monitoring_bp.route('/drivers/<int:driver_id>/score', methods=['GET'])
+@jwt_required()
+def get_driver_score(driver_id):
+    current_user_identity = get_jwt_identity()
+    is_current_user_the_driver = (current_user_identity.get('user_type') == 'driver' and
+                                  current_user_identity.get('id') == driver_id)
+
+    if not is_admin_user() and not is_current_user_the_driver:
+        return jsonify({"error": "Unauthorized. Admin access or viewing own score required."}), 403
+
+    target_driver_exists = any(u['id'] == driver_id and u['user_type'] == 'driver' for u in users_db.values())
+    if not target_driver_exists:
+        return jsonify({"error": f"Driver with id {driver_id} not found."}), 404
+
+    score = driver_scores_db.get(driver_id)
+    if not score:
+        return jsonify({
+            "driver_id": driver_id, "overall_safety_score": None, "efficiency_score": None,
+            "punctuality_score": None, "feedback_summary": "No score data available yet.",
+            "last_updated_timestamp": None
+        }), 200
+
+    return jsonify(score), 200
+
+
+@monitoring_bp.route('/drivers/<int:driver_id>/score', methods=['PUT'])
+@jwt_required()
+def update_driver_score(driver_id):
+    if not is_admin_user():
+        return jsonify({"error": "Unauthorized. Admin access required to update scores."}), 403
+
+    target_driver_exists = any(u['id'] == driver_id and u['user_type'] == 'driver' for u in users_db.values())
+    if not target_driver_exists:
+        return jsonify({"error": f"Driver with id {driver_id} not found."}), 404
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid input, JSON required"}), 400
+
+    current_score = driver_scores_db.get(driver_id, {})
+    updated_fields = False
+
+    if 'overall_safety_score' in data:
+        score_val = data['overall_safety_score']
+        if not (isinstance(score_val, (int, float)) and 0 <= score_val <= 100):
+            return jsonify({"error": "Invalid overall_safety_score. Must be a number between 0 and 100."}), 400
+        current_score['overall_safety_score'] = score_val
+        updated_fields = True
+
+    if 'efficiency_score' in data:
+        score_val = data['efficiency_score']
+        if not (isinstance(score_val, (int, float)) and 0 <= score_val <= 100):
+            return jsonify({"error": "Invalid efficiency_score. Must be a number between 0 and 100."}), 400
+        current_score['efficiency_score'] = score_val
+        updated_fields = True
+
+    if 'punctuality_score' in data:
+        score_val = data['punctuality_score']
+        if not (isinstance(score_val, (int, float)) and 0 <= score_val <= 100):
+            return jsonify({"error": "Invalid punctuality_score. Must be a number between 0 and 100."}), 400
+        current_score['punctuality_score'] = score_val
+        updated_fields = True
+
+    if 'feedback_summary' in data:
+        summary = data['feedback_summary']
+        if not isinstance(summary, str):
+            return jsonify({"error": "Invalid feedback_summary. Must be a string."}), 400
+        current_score['feedback_summary'] = summary
+        updated_fields = True
+
+    if not updated_fields and not driver_scores_db.get(driver_id):
+         return jsonify({"error": "No valid score fields provided for update."}), 400
+
+    current_score['driver_id'] = driver_id
+    current_score['last_updated_timestamp'] = datetime.datetime.utcnow().isoformat()
+
+    driver_scores_db[driver_id] = current_score
+    return jsonify({"message": "Driver score updated successfully", "score": current_score}), 200
+
+# --- Incident Logging & Reporting Endpoints ---
+
+@monitoring_bp.route('/incidents', methods=['POST'])
+@jwt_required()
+def log_incident_report():
+    if not is_admin_user():
+        return jsonify({"error": "Unauthorized. Admin access required to log incidents."}), 403
+
+    current_user_identity = get_jwt_identity()
+    reporter_id = current_user_identity.get('id')
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid input, JSON required"}), 400
+
+    required_fields = ['driver_id', 'incident_type', 'description']
+    for field in required_fields:
+        if field not in data:
+            return jsonify({"error": f"Missing required field: {field}"}), 400
+
+    driver_id = data.get('driver_id')
+    incident_type = data.get('incident_type')
+    description = data.get('description')
+    ride_id = data.get('ride_id')
+    status = data.get('status', 'open')
+
+    target_driver_exists = any(u['id'] == driver_id and u['user_type'] == 'driver' for u in users_db.values())
+    if not target_driver_exists:
+        return jsonify({"error": f"Driver with id {driver_id} not found."}), 404
+
+    valid_statuses = ['open', 'investigating', 'resolved', 'closed']
+    if status not in valid_statuses:
+        return jsonify({"error": f"Invalid status. Must be one of: {', '.join(valid_statuses)}"}), 400
+
+    report_id = id_manager.get_next_incident_report_id()
+    report_obj = {
+        "report_id": report_id, "driver_id": driver_id, "ride_id": ride_id,
+        "reported_by_user_id": reporter_id, "incident_type": incident_type,
+        "description": description, "status": status,
+        "created_at": datetime.datetime.utcnow().isoformat(),
+        "updated_at": datetime.datetime.utcnow().isoformat(),
+        "resolution_notes": None
+    }
+    incident_reports_db[report_id] = report_obj
+    return jsonify({"message": "Incident reported successfully", "report": report_obj}), 201
+
+
+@monitoring_bp.route('/incidents', methods=['GET'])
+@jwt_required()
+def get_all_incidents():
+    if not is_admin_user():
+        return jsonify({"error": "Unauthorized. Admin access required."}), 403
+
+    filter_driver_id = request.args.get('driver_id', type=int)
+    filter_status = request.args.get('status')
+
+    all_incidents = list(incident_reports_db.values())
+
+    if filter_driver_id is not None:
+        all_incidents = [report for report in all_incidents if report['driver_id'] == filter_driver_id]
+
+    if filter_status:
+        all_incidents = [report for report in all_incidents if report['status'] == filter_status]
+
+    all_incidents.sort(key=lambda x: x.get('created_at', ''), reverse=True)
+    return jsonify({"incidents": all_incidents}), 200
+
+
+@monitoring_bp.route('/incidents/<int:report_id>', methods=['GET'])
+@jwt_required()
+def get_incident_report_details(report_id):
+    if not is_admin_user():
+        return jsonify({"error": "Unauthorized. Admin access required."}), 403
+
+    report = incident_reports_db.get(report_id)
+    if not report:
+        return jsonify({"error": f"Incident report with id {report_id} not found."}), 404
+    return jsonify(report), 200
+
+
+@monitoring_bp.route('/incidents/<int:report_id>', methods=['PUT'])
+@jwt_required()
+def update_incident_report(report_id):
+    if not is_admin_user():
+        return jsonify({"error": "Unauthorized. Admin access required to update incidents."}), 403
+
+    report = incident_reports_db.get(report_id)
+    if not report:
+        return jsonify({"error": f"Incident report with id {report_id} not found."}), 404
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid input, JSON required"}), 400
+
+    updated_fields = False
+    if 'status' in data:
+        new_status = data['status']
+        valid_statuses = ['open', 'investigating', 'resolved', 'closed']
+        if new_status not in valid_statuses:
+            return jsonify({"error": f"Invalid status. Must be one of: {', '.join(valid_statuses)}"}), 400
+        report['status'] = new_status
+        updated_fields = True
+
+    if 'description' in data:
+        report['description'] = str(data['description'])
+        updated_fields = True
+
+    if 'resolution_notes' in data:
+        report['resolution_notes'] = str(data['resolution_notes']) if data['resolution_notes'] is not None else None
+        updated_fields = True
+
+    if not updated_fields:
+        return jsonify({"error": "No valid fields provided for update."}), 400
+
+    report['updated_at'] = datetime.datetime.utcnow().isoformat()
+    incident_reports_db[report_id] = report
+    return jsonify({"message": "Incident report updated successfully", "report": report}), 200

--- a/packnride_api/app/routes.py
+++ b/packnride_api/app/routes.py
@@ -1,0 +1,202 @@
+from flask import Blueprint, jsonify, request
+from app import rides_db, users_db, id_manager # Import DBs and ID manager
+from flask_jwt_extended import jwt_required, get_jwt_identity
+import datetime
+import random # For mock fare estimation
+
+main_bp = Blueprint('main_bp', __name__)
+
+@main_bp.route('/', methods=['GET'])
+def index():
+    return jsonify({"message": "Welcome to PacknRide API - Main Routes"}), 200
+
+# --- Ride Endpoints ---
+
+@main_bp.route('/rides/request', methods=['POST'])
+@jwt_required()
+def request_ride():
+    current_user_identity = get_jwt_identity() # This is the dict we stored
+    passenger_id = current_user_identity.get('id')
+    user_type = current_user_identity.get('user_type')
+
+    if user_type != 'passenger':
+        return jsonify({"error": "Only passengers can request rides"}), 403
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "Invalid input, JSON required"}), 400
+
+    pickup_location = data.get('pickup_location')
+    dropoff_location = data.get('dropoff_location')
+
+    if not pickup_location or not dropoff_location:
+        return jsonify({"error": "Missing pickup_location or dropoff_location"}), 400
+
+    ride_id = id_manager.get_next_ride_id()
+
+    ride_obj = {
+        "id": ride_id,
+        "passenger_id": passenger_id,
+        "driver_id": None,
+        "pickup_location": pickup_location,
+        "dropoff_location": dropoff_location,
+        "status": "pending", # pending, accepted, en_route_pickup, arrived_pickup, started, completed, cancelled
+        "fare": None,
+        "requested_at": datetime.datetime.utcnow().isoformat(),
+        "updated_at": datetime.datetime.utcnow().isoformat()
+    }
+    rides_db[ride_id] = ride_obj
+
+    return jsonify({"message": "Ride requested successfully", "ride": ride_obj}), 201
+
+
+@main_bp.route('/rides/<int:ride_id>', methods=['GET'])
+@jwt_required()
+def get_ride_details(ride_id):
+    current_user_identity = get_jwt_identity()
+    user_id = current_user_identity.get('id')
+    # user_type = current_user_identity.get('user_type') # Not strictly needed here but good for clarity
+
+    ride = rides_db.get(ride_id)
+    if not ride:
+        return jsonify({"error": "Ride not found"}), 404
+
+    # Allow passenger who requested or assigned driver to see details
+    if not (ride['passenger_id'] == user_id or (ride['driver_id'] and ride['driver_id'] == user_id)):
+        return jsonify({"error": "Access forbidden: You are not part of this ride"}), 403
+
+    return jsonify(ride), 200
+
+
+@main_bp.route('/rides/<int:ride_id>/accept', methods=['POST'])
+@jwt_required()
+def accept_ride(ride_id):
+    current_user_identity = get_jwt_identity()
+    driver_id = current_user_identity.get('id')
+    user_type = current_user_identity.get('user_type')
+
+    if user_type != 'driver':
+        return jsonify({"error": "Only drivers can accept rides"}), 403
+
+    ride = rides_db.get(ride_id)
+    if not ride:
+        return jsonify({"error": "Ride not found"}), 404
+
+    if ride['status'] != 'pending':
+        return jsonify({"error": f"Ride cannot be accepted, current status: {ride['status']}"}), 400
+
+    if ride['driver_id'] is not None: # Check if another driver already accepted it
+        return jsonify({"error": "Ride already accepted by another driver"}), 409 # Conflict
+
+    ride['driver_id'] = driver_id
+    ride['status'] = 'accepted'
+    ride['updated_at'] = datetime.datetime.utcnow().isoformat()
+
+    rides_db[ride_id] = ride # Update the ride in our 'DB'
+
+    return jsonify({"message": "Ride accepted successfully", "ride": ride}), 200
+
+
+@main_bp.route('/rides/<int:ride_id>/status', methods=['PUT'])
+@jwt_required()
+def update_ride_status(ride_id):
+    current_user_identity = get_jwt_identity()
+    user_id = current_user_identity.get('id')
+    user_type = current_user_identity.get('user_type')
+
+    ride = rides_db.get(ride_id)
+    if not ride:
+        return jsonify({"error": "Ride not found"}), 404
+
+    data = request.get_json()
+    if not data or 'status' not in data:
+        return jsonify({"error": "Missing 'status' in request body"}), 400
+
+    new_status = data['status']
+
+    # Define valid statuses and transitions (simplified)
+    valid_statuses = ['en_route_pickup', 'arrived_pickup', 'started', 'completed', 'cancelled']
+    if new_status not in valid_statuses:
+        return jsonify({"error": f"Invalid status: {new_status}"}), 400
+
+    # Permissions for status updates (simplified)
+    can_update = False
+    if user_type == 'driver' and ride['driver_id'] == user_id:
+        if ride['status'] == 'accepted' and new_status == 'en_route_pickup': can_update = True
+        elif ride['status'] == 'en_route_pickup' and new_status == 'arrived_pickup': can_update = True
+        elif ride['status'] == 'arrived_pickup' and new_status == 'started': can_update = True
+        elif ride['status'] == 'started' and new_status == 'completed':
+            can_update = True
+            # Mock fare calculation on completion
+            ride['fare'] = round(random.uniform(5.0, 50.0) * 100) / 100 # Mock fare e.g., R25.50
+        elif new_status == 'cancelled': # Driver can cancel before pickup, or if passenger no-show
+            if ride['status'] in ['accepted', 'en_route_pickup', 'arrived_pickup']: can_update = True
+    elif user_type == 'passenger' and ride['passenger_id'] == user_id:
+        if new_status == 'cancelled': # Passenger can cancel
+            if ride['status'] in ['pending', 'accepted', 'en_route_pickup']: can_update = True # Can cancel before driver starts trip
+
+    if not can_update:
+         return jsonify({"error": f"Cannot transition from '{ride['status']}' to '{new_status}' or not authorized"}), 403
+
+    ride['status'] = new_status
+    ride['updated_at'] = datetime.datetime.utcnow().isoformat()
+    rides_db[ride_id] = ride
+
+    return jsonify({"message": f"Ride status updated to {new_status}", "ride": ride}), 200
+
+
+# --- Driver Endpoints ---
+
+@main_bp.route('/drivers/nearby', methods=['GET'])
+@jwt_required() # Passenger needs to be logged in to see nearby drivers
+def get_nearby_drivers():
+    # This is a MOCKED endpoint. In a real app, this would involve geospatial queries.
+    current_user_identity = get_jwt_identity()
+    if current_user_identity.get('user_type') != 'passenger':
+         return jsonify({"error": "Only passengers can search for nearby drivers"}), 403
+
+    # Mocking: Return a list of all 'driver' type users who are not currently on an active ride
+    available_drivers = []
+    for _email, user in users_db.items(): # Iterate through users_db which is keyed by email
+        if user['user_type'] == 'driver':
+            is_on_active_ride = False
+            for _ride_id, ride_data in rides_db.items(): # Iterate through rides_db
+                if ride_data['driver_id'] == user['id'] and ride_data['status'] not in ['completed', 'cancelled']:
+                    is_on_active_ride = True
+                    break
+            if not is_on_active_ride:
+                available_drivers.append({
+                    "id": user['id'],
+                    "name": user['name'],
+                    "mock_location": f"Nearby Location {random.randint(1, 100)}",
+                    "vehicle_type": "Sedan", # Mocked
+                    "current_status": "available" # Mocked
+                })
+
+    return jsonify({"available_drivers": available_drivers}), 200
+
+# --- Fare Estimation ---
+@main_bp.route('/rides/estimate_fare', methods=['POST'])
+@jwt_required()
+def estimate_fare():
+    # MOCKED endpoint
+    data = request.get_json()
+    if not data or not data.get('pickup_location') or not data.get('dropoff_location'):
+        return jsonify({"error": "pickup_location and dropoff_location required"}), 400
+
+    pickup = data.get('pickup_location', "")
+    dropoff = data.get('dropoff_location', "")
+
+    # Very simple mock: longer names = higher price, plus some randomness
+    base_fare = 10.0
+    distance_factor = (len(pickup) + len(dropoff)) * 0.1 # Arbitrary calculation
+    random_surge = random.uniform(0.8, 1.5)
+    estimated_fare = round((base_fare + distance_factor) * random_surge * 100) / 100 # e.g. RXX.XX
+
+    return jsonify({
+        "pickup_location": pickup,
+        "dropoff_location": dropoff,
+        "estimated_fare_rand": f"R{estimated_fare:.2f}", # South African Rand
+        "currency": "ZAR",
+        "note": "This is a mock estimation. Actual fare may vary."
+    }), 200

--- a/packnride_api/app/utils.py
+++ b/packnride_api/app/utils.py
@@ -1,0 +1,13 @@
+from passlib.context import CryptContext
+
+# Initialize CryptContext for password hashing
+# Using bcrypt as the default hashing scheme
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def hash_password(password: str) -> str:
+    """Hashes a password using the configured context."""
+    return pwd_context.hash(password)
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verifies a plain password against a hashed password."""
+    return pwd_context.verify(plain_password, hashed_password)

--- a/packnride_api/config.py
+++ b/packnride_api/config.py
@@ -1,0 +1,49 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv() # Load environment variables from .env file (if it exists)
+
+class Config:
+    """Base configuration."""
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'your_default_secret_key')
+    JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY', 'your_default_jwt_secret_key')
+    # Add other configurations here
+    DEBUG = False
+    TESTING = False
+
+class DevelopmentConfig(Config):
+    """Development configuration."""
+    DEBUG = True
+
+class TestingConfig(Config):
+    """Testing configuration."""
+    TESTING = True
+    # Example: Use an in-memory SQLite database for tests if we add a DB
+    # SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+
+class ProductionConfig(Config):
+    """Production configuration."""
+    # Production specific settings
+    # For example, load sensitive keys from environment variables
+    SECRET_KEY = os.environ.get('SECRET_KEY')
+    JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY')
+    if not SECRET_KEY or not JWT_SECRET_KEY:
+        # In a real production environment, you'd want to ensure these are set
+        # and potentially raise an error or log a critical warning.
+        # For now, we'll just print a warning if they're not found.
+        print("WARNING: SECRET_KEY or JWT_SECRET_KEY not set in environment for ProductionConfig.")
+        if not SECRET_KEY:
+            SECRET_KEY = 'prod_default_secret_key_fallback' # Fallback for safety, but not recommended
+        if not JWT_SECRET_KEY:
+            JWT_SECRET_KEY = 'prod_default_jwt_secret_key_fallback' # Fallback for safety
+
+# Simple way to get the config based on an environment variable
+# You might set FLASK_ENV to 'development', 'testing', or 'production'
+env_config = os.environ.get('FLASK_ENV', 'development').lower()
+
+if env_config == 'production':
+    app_config = ProductionConfig()
+elif env_config == 'testing':
+    app_config = TestingConfig()
+else:
+    app_config = DevelopmentConfig()

--- a/packnride_api/requirements.txt
+++ b/packnride_api/requirements.txt
@@ -1,0 +1,8 @@
+Flask
+Flask-JWT-Extended
+Werkzeug
+python-dotenv
+passlib
+bcrypt
+pytest
+pytest-flask

--- a/packnride_api/run.py
+++ b/packnride_api/run.py
@@ -1,0 +1,12 @@
+from app import create_app
+from config import app_config
+
+app = create_app(app_config)
+
+if __name__ == '__main__':
+    # Ensure FLASK_ENV is set, or default to development for running directly
+    # The app_config loaded by create_app already considers FLASK_ENV
+    host = '0.0.0.0'
+    port = 5000 # Standard Flask port
+    print(f"Starting PacknRide API on {host}:{port} with config: {app.config['ENV']}")
+    app.run(host=host, port=port, debug=app.config['DEBUG'])

--- a/packnride_api/tests/conftest.py
+++ b/packnride_api/tests/conftest.py
@@ -1,0 +1,101 @@
+import pytest
+from app import create_app, users_db, rides_db, id_manager
+from config import TestingConfig # Make sure TestingConfig is appropriate
+
+@pytest.fixture(scope='session')
+def app():
+    """Create and configure a new app instance for each test session."""
+    # Ensure a clean state for each test session if needed,
+    # though for module/function scope fixtures, this might be handled differently.
+    # For in-memory dbs, they might persist across a session if not careful.
+    app = create_app(TestingConfig)
+
+    # Ensure FLASK_ENV is set to testing for the app context
+    app.config['ENV'] = 'testing' # Redundant if TestingConfig sets it, but good for clarity
+    app.config['TESTING'] = True
+
+    # If you need to clean up global in-memory stores between test *sessions*
+    # you could do it here, but typically test isolation is preferred at a finer grain.
+    # For this example, we'll rely on test functions to manage state or use function-scoped fixtures
+    # if state needs to be reset for every test.
+
+    yield app # Provide the app instance
+
+@pytest.fixture(scope='function') # Use function scope to get a fresh client and clean dbs for each test
+def client(app):
+    """A test client for the app."""
+    # Reset in-memory 'databases' and ID counters before each test function
+    users_db.clear()
+    rides_db.clear()
+    # Reset ID counters by creating a new IDManager instance or resetting its internal counters
+    # For simplicity, let's re-initialize its counters if possible, or replace the instance.
+    # Accessing id_manager directly from app might be tricky if it's not exposed.
+    # The simplest way for this example:
+    id_manager.user_id_counter = 0
+    id_manager.ride_id_counter = 0
+
+    with app.test_client() as client:
+        with app.app_context(): # Push an application context
+            yield client
+
+# You can add more fixtures here, e.g., for creating authenticated users
+@pytest.fixture(scope='function')
+def registered_user(client):
+    """Fixture to register and return a user's details and token."""
+    user_data = {
+        "name": "Test User",
+        "email": "test@example.com",
+        "password": "password123",
+        "user_type": "passenger"
+    }
+    client.post('/auth/register', json=user_data) # Register the user
+
+    # Login to get token
+    login_resp = client.post('/auth/login', json={
+        "email": "test@example.com",
+        "password": "password123"
+    })
+    token = login_resp.get_json()['access_token']
+
+    # Return user_data along with id (which we don't easily get back from register)
+    # and the token. For tests, we might need the user's ID.
+    # users_db is keyed by email, so we can retrieve the registered user.
+    user_obj = users_db.get("test@example.com")
+    user_id = user_obj["id"] if user_obj else None # Handle case where user might not be found if test setup fails
+
+    return {
+        "email": user_data["email"],
+        "password": user_data["password"],
+        "name": user_data["name"],
+        "user_type": user_data["user_type"],
+        "id": user_id,
+        "token": token
+    }
+
+@pytest.fixture(scope='function')
+def registered_driver(client):
+    """Fixture to register and return a driver's details and token."""
+    driver_data = {
+        "name": "Test Driver",
+        "email": "driver@example.com",
+        "password": "password123",
+        "user_type": "driver"
+    }
+    client.post('/auth/register', json=driver_data)
+
+    login_resp = client.post('/auth/login', json={
+        "email": "driver@example.com",
+        "password": "password123"
+    })
+    token = login_resp.get_json()['access_token']
+    driver_obj = users_db.get("driver@example.com")
+    driver_id = driver_obj["id"] if driver_obj else None
+
+    return {
+        "email": driver_data["email"],
+        "password": driver_data["password"],
+        "name": driver_data["name"],
+        "user_type": driver_data["user_type"],
+        "id": driver_id,
+        "token": token
+    }

--- a/packnride_api/tests/conftest.py
+++ b/packnride_api/tests/conftest.py
@@ -1,101 +1,87 @@
 import pytest
-from app import create_app, users_db, rides_db, id_manager
-from config import TestingConfig # Make sure TestingConfig is appropriate
+from app import create_app, users_db, rides_db, id_manager, driving_events_db, driver_scores_db, incident_reports_db
+from config import TestingConfig
 
 @pytest.fixture(scope='session')
 def app():
-    """Create and configure a new app instance for each test session."""
-    # Ensure a clean state for each test session if needed,
-    # though for module/function scope fixtures, this might be handled differently.
-    # For in-memory dbs, they might persist across a session if not careful.
     app = create_app(TestingConfig)
-
-    # Ensure FLASK_ENV is set to testing for the app context
-    app.config['ENV'] = 'testing' # Redundant if TestingConfig sets it, but good for clarity
+    app.config['ENV'] = 'testing'
     app.config['TESTING'] = True
+    yield app
 
-    # If you need to clean up global in-memory stores between test *sessions*
-    # you could do it here, but typically test isolation is preferred at a finer grain.
-    # For this example, we'll rely on test functions to manage state or use function-scoped fixtures
-    # if state needs to be reset for every test.
-
-    yield app # Provide the app instance
-
-@pytest.fixture(scope='function') # Use function scope to get a fresh client and clean dbs for each test
+@pytest.fixture(scope='function')
 def client(app):
-    """A test client for the app."""
     # Reset in-memory 'databases' and ID counters before each test function
     users_db.clear()
     rides_db.clear()
-    # Reset ID counters by creating a new IDManager instance or resetting its internal counters
-    # For simplicity, let's re-initialize its counters if possible, or replace the instance.
-    # Accessing id_manager directly from app might be tricky if it's not exposed.
-    # The simplest way for this example:
+    driving_events_db.clear()
+    driver_scores_db.clear()
+    incident_reports_db.clear()
+
+    # Reset IDManager counters
     id_manager.user_id_counter = 0
     id_manager.ride_id_counter = 0
+    id_manager.driving_event_id_counter = 0
+    id_manager.incident_report_id_counter = 0
 
     with app.test_client() as client:
-        with app.app_context(): # Push an application context
+        with app.app_context():
             yield client
 
-# You can add more fixtures here, e.g., for creating authenticated users
 @pytest.fixture(scope='function')
 def registered_user(client):
-    """Fixture to register and return a user's details and token."""
     user_data = {
-        "name": "Test User",
-        "email": "test@example.com",
-        "password": "password123",
-        "user_type": "passenger"
+        "name": "Test User", "email": "test@example.com",
+        "password": "password123", "user_type": "passenger"
     }
-    client.post('/auth/register', json=user_data) # Register the user
-
-    # Login to get token
-    login_resp = client.post('/auth/login', json={
-        "email": "test@example.com",
-        "password": "password123"
-    })
-    token = login_resp.get_json()['access_token']
-
-    # Return user_data along with id (which we don't easily get back from register)
-    # and the token. For tests, we might need the user's ID.
-    # users_db is keyed by email, so we can retrieve the registered user.
-    user_obj = users_db.get("test@example.com")
-    user_id = user_obj["id"] if user_obj else None # Handle case where user might not be found if test setup fails
-
-    return {
-        "email": user_data["email"],
-        "password": user_data["password"],
-        "name": user_data["name"],
-        "user_type": user_data["user_type"],
-        "id": user_id,
-        "token": token
-    }
+    client.post('/auth/register', json=user_data)
+    login_resp = client.post('/auth/login', json={"email": user_data["email"], "password": user_data["password"]})
+    token = login_resp.get_json().get('access_token')
+    user_obj = users_db.get(user_data["email"])
+    user_id = user_obj["id"] if user_obj else None
+    return {**user_data, "id": user_id, "token": token}
 
 @pytest.fixture(scope='function')
 def registered_driver(client):
-    """Fixture to register and return a driver's details and token."""
     driver_data = {
-        "name": "Test Driver",
-        "email": "driver@example.com",
-        "password": "password123",
-        "user_type": "driver"
+        "name": "Test Driver", "email": "driver@example.com",
+        "password": "password123", "user_type": "driver"
     }
     client.post('/auth/register', json=driver_data)
+    login_resp = client.post('/auth/login', json={"email": driver_data["email"], "password": driver_data["password"]})
+    token = login_resp.get_json().get('access_token')
+    driver_obj = users_db.get(driver_data["email"])
+    driver_id = driver_obj["id"] if driver_obj else None
+    return {**driver_data, "id": driver_id, "token": token}
+
+@pytest.fixture(scope='function')
+def registered_admin(client):
+    """Fixture to register and return an admin user's details and token."""
+    admin_data = {
+        "name": "Admin User",
+        "email": "admin@example.com",
+        "password": "adminpassword",
+        "user_type": "passenger", # Admins can be any user_type, is_admin flag is key
+        "is_admin": True
+    }
+    client.post('/auth/register', json=admin_data)
 
     login_resp = client.post('/auth/login', json={
-        "email": "driver@example.com",
-        "password": "password123"
+        "email": admin_data["email"],
+        "password": admin_data["password"]
     })
-    token = login_resp.get_json()['access_token']
-    driver_obj = users_db.get("driver@example.com")
-    driver_id = driver_obj["id"] if driver_obj else None
+    json_data = login_resp.get_json()
+    token = json_data.get('access_token') if json_data else None
+
+    admin_obj = users_db.get(admin_data["email"])
+    admin_id = admin_obj.get("id") if admin_obj else None
 
     return {
-        "email": driver_data["email"],
-        "password": driver_data["password"],
-        "name": driver_data["name"],
-        "user_type": driver_data["user_type"],
-        "id": driver_id,
+        "email": admin_data["email"],
+        "password": admin_data["password"],
+        "name": admin_data["name"],
+        "user_type": admin_data["user_type"],
+        "is_admin": True,
+        "id": admin_id,
         "token": token
     }

--- a/packnride_api/tests/test_auth.py
+++ b/packnride_api/tests/test_auth.py
@@ -1,0 +1,125 @@
+import pytest
+from flask import jsonify # Not strictly needed for client tests but useful for constructing expected JSON
+
+def test_health_check(client):
+    """Test the health check endpoint."""
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert b"PacknRide API is healthy!" in response.data
+
+def test_register_passenger_success(client):
+    """Test successful passenger registration."""
+    response = client.post('/auth/register', json={
+        "name": "Alice Wonderland",
+        "email": "alice@example.com",
+        "password": "password123",
+        "user_type": "passenger"
+    })
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert json_data['message'] == "User registered successfully"
+    assert json_data['user']['email'] == "alice@example.com"
+    assert json_data['user']['user_type'] == "passenger"
+    assert json_data['user']['id'] is not None
+
+def test_register_driver_success(client):
+    """Test successful driver registration."""
+    response = client.post('/auth/register', json={
+        "name": "Bob The Driver",
+        "email": "bob@example.com",
+        "password": "passwordDRV",
+        "user_type": "driver"
+    })
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert json_data['user']['email'] == "bob@example.com"
+    assert json_data['user']['user_type'] == "driver"
+
+def test_register_duplicate_email(client):
+    """Test registration with a duplicate email."""
+    user_data = {
+        "name": "Charlie Brown",
+        "email": "charlie@example.com",
+        "password": "passwordCB",
+        "user_type": "passenger"
+    }
+    response1 = client.post('/auth/register', json=user_data)
+    assert response1.status_code == 201
+
+    response2 = client.post('/auth/register', json=user_data) # Try registering again
+    assert response2.status_code == 409 # Conflict
+    assert "Email already registered" in response2.get_json()['error']
+
+def test_register_missing_fields(client):
+    """Test registration with missing fields."""
+    response = client.post('/auth/register', json={
+        "name": "Incomplete User",
+        "email": "incomplete@example.com"
+        # Missing password
+    })
+    assert response.status_code == 400
+    assert "Missing name, email, or password" in response.get_json()['error'] # Or specific missing field
+
+def test_register_invalid_user_type(client):
+    """Test registration with an invalid user type."""
+    response = client.post('/auth/register', json={
+        "name": "Invalid TypeUser",
+        "email": "invalidtype@example.com",
+        "password": "password123",
+        "user_type": "admin" # Invalid type
+    })
+    assert response.status_code == 400
+    assert "Invalid user_type" in response.get_json()['error']
+
+def test_login_success(client, registered_user): # Uses the registered_user fixture
+    """Test successful login."""
+    login_payload = {
+        "email": registered_user['email'],
+        "password": registered_user['password']
+    }
+    response = client.post('/auth/login', json=login_payload)
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert "access_token" in json_data
+    assert json_data['access_token'] is not None
+
+def test_login_wrong_password(client, registered_user):
+    """Test login with an incorrect password."""
+    login_payload = {
+        "email": registered_user['email'],
+        "password": "wrongpassword"
+    }
+    response = client.post('/auth/login', json=login_payload)
+    assert response.status_code == 401 # Unauthorized
+    assert "Invalid credentials" in response.get_json()['error']
+
+def test_login_user_not_found(client):
+    """Test login for a user that does not exist."""
+    login_payload = {
+        "email": "nonexistent@example.com",
+        "password": "password123"
+    }
+    response = client.post('/auth/login', json=login_payload)
+    assert response.status_code == 404 # Not Found
+    assert "Email not found" in response.get_json()['error']
+
+def test_login_missing_fields(client):
+    """Test login with missing email or password."""
+    response = client.post('/auth/login', json={"email": "test@example.com"})
+    assert response.status_code == 400
+    assert "Missing email or password" in response.get_json()['error']
+
+    response = client.post('/auth/login', json={"password": "password123"})
+    assert response.status_code == 400
+    assert "Missing email or password" in response.get_json()['error']
+
+# Example of how to test a protected route (if we had one in auth.py)
+# def test_protected_route_requires_token(client):
+#     response = client.get('/auth/protected') # Assuming /auth/protected exists and is @jwt_required
+#     assert response.status_code == 401 # No token provided
+
+# def test_protected_route_with_valid_token(client, registered_user):
+#     headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+#     response = client.get('/auth/protected', headers=headers)
+#     assert response.status_code == 200
+#     assert response.get_json()['logged_in_as']['email'] == registered_user['email']

--- a/packnride_api/tests/test_monitoring.py
+++ b/packnride_api/tests/test_monitoring.py
@@ -1,0 +1,204 @@
+import pytest
+import datetime
+from app import driving_events_db, driver_scores_db, incident_reports_db # For direct inspection if needed
+
+# --- Test Driving Event Endpoints ---
+
+def test_log_driving_event_by_admin(client, registered_admin, registered_driver):
+    """Admin logs a driving event for a driver."""
+    headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+    event_data = {
+        "driver_id": registered_driver["id"],
+        "event_type": "speeding",
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "location_lat": -25.7479,
+        "location_lon": 28.2293,
+        "details": {"speed_kmh": 100, "limit_kmh": 60}
+    }
+    response = client.post('/api/monitoring/events', headers=headers, json=event_data)
+    assert response.status_code == 201
+    json_resp = response.get_json()['event']
+    assert json_resp['driver_id'] == registered_driver["id"]
+    assert json_resp['event_type'] == "speeding"
+
+def test_log_driving_event_by_driver_self(client, registered_driver):
+    """Driver logs their own driving event."""
+    headers = {'Authorization': f'Bearer {registered_driver["token"]}'}
+    event_data = {
+        "driver_id": registered_driver["id"], # Must match self
+        "event_type": "harsh_braking",
+        "timestamp": datetime.datetime.utcnow().isoformat(),
+        "location_lat": -25.7470,
+        "location_lon": 28.2290,
+        "details": {"g_force": 0.8}
+    }
+    response = client.post('/api/monitoring/events', headers=headers, json=event_data)
+    assert response.status_code == 201
+    assert response.get_json()['event']['event_type'] == "harsh_braking"
+
+def test_log_driving_event_unauthorized(client, registered_user, registered_driver):
+    """Non-admin passenger tries to log event for another driver."""
+    headers = {'Authorization': f'Bearer {registered_user["token"]}'} # Passenger token
+    event_data = {"driver_id": registered_driver["id"], "event_type": "test", "timestamp": datetime.datetime.utcnow().isoformat(), "location_lat":0.0, "location_lon":0.0}
+    response = client.post('/api/monitoring/events', headers=headers, json=event_data)
+    assert response.status_code == 403 # Forbidden
+
+def test_get_driver_events_by_admin(client, registered_admin, registered_driver):
+    """Admin gets events for a specific driver."""
+    # Log an event first
+    admin_headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+    client.post('/api/monitoring/events', headers=admin_headers, json={
+        "driver_id": registered_driver["id"], "event_type": "idling",
+        "timestamp": datetime.datetime.utcnow().isoformat(), "location_lat":0.0, "location_lon":0.0
+    })
+
+    response = client.get(f'/api/monitoring/drivers/{registered_driver["id"]}/events', headers=admin_headers)
+    assert response.status_code == 200
+    json_resp = response.get_json()
+    assert isinstance(json_resp['events'], list)
+    assert len(json_resp['events']) > 0
+    assert json_resp['events'][0]['event_type'] == "idling"
+
+def test_get_driver_events_by_self(client, registered_driver):
+    """Driver gets their own events."""
+    driver_headers = {'Authorization': f'Bearer {registered_driver["token"]}'}
+    client.post('/api/monitoring/events', headers=driver_headers, json={
+        "driver_id": registered_driver["id"], "event_type": "cornering",
+        "timestamp": datetime.datetime.utcnow().isoformat(), "location_lat":0.0, "location_lon":0.0
+    })
+    response = client.get(f'/api/monitoring/drivers/{registered_driver["id"]}/events', headers=driver_headers)
+    assert response.status_code == 200
+    assert len(response.get_json()['events']) > 0
+
+# --- Test Driver Performance Score Endpoints ---
+
+def test_get_driver_score_initial(client, registered_admin, registered_driver):
+    """Admin gets initial (empty) score for a driver."""
+    headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+    response = client.get(f'/api/monitoring/drivers/{registered_driver["id"]}/score', headers=headers)
+    assert response.status_code == 200
+    json_resp = response.get_json()
+    assert json_resp['overall_safety_score'] is None
+    assert "No score data available yet" in json_resp['feedback_summary']
+
+def test_update_and_get_driver_score_by_admin(client, registered_admin, registered_driver):
+    """Admin updates and then gets a driver's score."""
+    headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+    score_data = {
+        "overall_safety_score": 85.5,
+        "efficiency_score": 90,
+        "feedback_summary": "Good performance."
+    }
+    put_response = client.put(f'/api/monitoring/drivers/{registered_driver["id"]}/score', headers=headers, json=score_data)
+    assert put_response.status_code == 200
+    assert put_response.get_json()['score']['overall_safety_score'] == 85.5
+
+    get_response = client.get(f'/api/monitoring/drivers/{registered_driver["id"]}/score', headers=headers)
+    assert get_response.status_code == 200
+    json_resp = get_response.get_json()
+    assert json_resp['overall_safety_score'] == 85.5
+    assert json_resp['efficiency_score'] == 90
+    assert json_resp['feedback_summary'] == "Good performance."
+
+def test_update_driver_score_invalid_value(client, registered_admin, registered_driver):
+    headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+    score_data = {"overall_safety_score": 101} # Invalid
+    response = client.put(f'/api/monitoring/drivers/{registered_driver["id"]}/score', headers=headers, json=score_data)
+    assert response.status_code == 400
+
+
+# --- Test Incident Logging & Reporting Endpoints ---
+
+def test_log_incident_report_by_admin(client, registered_admin, registered_driver):
+    """Admin logs an incident report."""
+    headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+    incident_data = {
+        "driver_id": registered_driver["id"],
+        "incident_type": "minor_accident",
+        "description": "Scratched bumper in parking lot.",
+        "status": "open"
+    }
+    response = client.post('/api/monitoring/incidents', headers=headers, json=incident_data)
+    assert response.status_code == 201
+    json_resp = response.get_json()['report']
+    assert json_resp['driver_id'] == registered_driver["id"]
+    assert json_resp['incident_type'] == "minor_accident"
+    assert json_resp['reported_by_user_id'] == registered_admin["id"]
+
+def test_get_all_incidents_by_admin(client, registered_admin, registered_driver):
+    """Admin gets all incidents, with filtering."""
+    headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+    # Log one incident
+    client.post('/api/monitoring/incidents', headers=headers, json={
+        "driver_id": registered_driver["id"], "incident_type": "complaint",
+        "description": "Passenger complaint about music.", "status": "investigating"
+    })
+
+    response = client.get('/api/monitoring/incidents', headers=headers)
+    assert response.status_code == 200
+    assert len(response.get_json()['incidents']) >= 1
+
+    # Test filtering
+    response_filtered = client.get(f'/api/monitoring/incidents?driver_id={registered_driver["id"]}&status=investigating', headers=headers)
+    assert response_filtered.status_code == 200
+    assert len(response_filtered.get_json()['incidents']) == 1
+    assert response_filtered.get_json()['incidents'][0]['incident_type'] == "complaint"
+
+
+def test_get_specific_incident_by_admin(client, registered_admin, registered_driver):
+    """Admin gets details of a specific incident."""
+    headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+    post_resp = client.post('/api/monitoring/incidents', headers=headers, json={
+        "driver_id": registered_driver["id"], "incident_type": "speed_warning",
+        "description": "Exceeded speed by 20 km/h", "status": "open"
+    })
+    report_id = post_resp.get_json()['report']['report_id']
+
+    response = client.get(f'/api/monitoring/incidents/{report_id}', headers=headers)
+    assert response.status_code == 200
+    assert response.get_json()['report_id'] == report_id
+
+def test_update_incident_report_by_admin(client, registered_admin, registered_driver):
+    """Admin updates an incident report."""
+    headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+    post_resp = client.post('/api/monitoring/incidents', headers=headers, json={
+        "driver_id": registered_driver["id"], "incident_type": "vehicle_issue",
+        "description": "Flat tire reported.", "status": "open"
+    })
+    report_id = post_resp.get_json()['report']['report_id']
+
+    update_data = {"status": "resolved", "resolution_notes": "Tire replaced by roadside assistance."}
+    response = client.put(f'/api/monitoring/incidents/{report_id}', headers=headers, json=update_data)
+    assert response.status_code == 200
+    json_resp = response.get_json()['report']
+    assert json_resp['status'] == "resolved"
+    assert json_resp['resolution_notes'] == "Tire replaced by roadside assistance."
+
+def test_incident_access_by_non_admin_fails(client, registered_user, registered_admin, registered_driver): # Added registered_admin to ensure it's available
+    """Non-admin attempts to access incident endpoints."""
+    # Need an incident created by an admin first
+    # Use the admin fixture directly
+    admin_headers = {'Authorization': f'Bearer {registered_admin["token"]}'}
+
+    post_resp = client.post('/api/monitoring/incidents', headers=admin_headers, json={
+        "driver_id": registered_driver["id"], "incident_type": "test_incident",
+        "description": "A test incident.", "status": "open"
+    })
+    assert post_resp.status_code == 201 # Ensure incident created
+    report_id = post_resp.get_json()['report']['report_id']
+
+
+    user_headers = {'Authorization': f'Bearer {registered_user["token"]}'} # Passenger/non-admin
+
+    response_post = client.post('/api/monitoring/incidents', headers=user_headers, json={
+        "driver_id": registered_driver["id"], "incident_type": "another_incident", "description": "..."})
+    assert response_post.status_code == 403
+
+    response_get_all = client.get('/api/monitoring/incidents', headers=user_headers)
+    assert response_get_all.status_code == 403
+
+    response_get_one = client.get(f'/api/monitoring/incidents/{report_id}', headers=user_headers)
+    assert response_get_one.status_code == 403
+
+    response_put = client.put(f'/api/monitoring/incidents/{report_id}', headers=user_headers, json={"status": "closed"})
+    assert response_put.status_code == 403

--- a/packnride_api/tests/test_rides.py
+++ b/packnride_api/tests/test_rides.py
@@ -1,0 +1,216 @@
+import pytest
+
+def test_request_ride_success(client, registered_user):
+    """Test successful ride request by a passenger."""
+    headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    ride_payload = {
+        "pickup_location": "1 Main St",
+        "dropoff_location": "10 End Rd"
+    }
+    response = client.post('/api/rides/request', headers=headers, json=ride_payload)
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert json_data['message'] == "Ride requested successfully"
+    assert json_data['ride']['pickup_location'] == "1 Main St"
+    assert json_data['ride']['status'] == "pending"
+    assert json_data['ride']['passenger_id'] == registered_user['id']
+
+def test_request_ride_by_driver_fails(client, registered_driver):
+    """Test that a driver cannot request a ride."""
+    headers = {'Authorization': f'Bearer {registered_driver["token"]}'}
+    ride_payload = {
+        "pickup_location": "Driver Home",
+        "dropoff_location": "Driver Work"
+    }
+    response = client.post('/api/rides/request', headers=headers, json=ride_payload)
+    assert response.status_code == 403
+    assert "Only passengers can request rides" in response.get_json()['error']
+
+def test_request_ride_missing_location(client, registered_user):
+    """Test ride request with missing location data."""
+    headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    ride_payload = {"pickup_location": "1 Main St"} # Missing dropoff
+    response = client.post('/api/rides/request', headers=headers, json=ride_payload)
+    assert response.status_code == 400
+    assert "Missing pickup_location or dropoff_location" in response.get_json()['error']
+
+def test_get_ride_details_success(client, registered_user):
+    """Test passenger getting their ride details."""
+    headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    # First, request a ride
+    ride_payload = {"pickup_location": "Origin", "dropoff_location": "Destination"}
+    post_response = client.post('/api/rides/request', headers=headers, json=ride_payload)
+    assert post_response.status_code == 201
+    ride_id = post_response.get_json()['ride']['id']
+
+    # Get details for that ride
+    get_response = client.get(f'/api/rides/{ride_id}', headers=headers)
+    assert get_response.status_code == 200
+    json_data = get_response.get_json()
+    assert json_data['id'] == ride_id
+    assert json_data['passenger_id'] == registered_user['id']
+
+def test_get_ride_details_unauthorized(client, registered_user, registered_driver):
+    """Test that a user cannot get details of a ride they are not part of."""
+    # Passenger 1 requests a ride
+    passenger1_headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    ride_payload = {"pickup_location": "P1 Start", "dropoff_location": "P1 End"}
+    post_response = client.post('/api/rides/request', headers=passenger1_headers, json=ride_payload)
+    assert post_response.status_code == 201
+    ride_id = post_response.get_json()['ride']['id']
+
+    # Driver (not yet assigned) tries to access
+    driver_headers = {'Authorization': f'Bearer {registered_driver["token"]}'}
+    get_response_driver = client.get(f'/api/rides/{ride_id}', headers=driver_headers)
+    assert get_response_driver.status_code == 403 # Forbidden as driver is not yet assigned
+
+def test_accept_ride_success(client, registered_user, registered_driver):
+    """Test successful ride acceptance by a driver."""
+    # Passenger requests a ride
+    passenger_headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    ride_payload = {"pickup_location": "Cafe", "dropoff_location": "Home"}
+    post_response = client.post('/api/rides/request', headers=passenger_headers, json=ride_payload)
+    ride_id = post_response.get_json()['ride']['id']
+
+    # Driver accepts the ride
+    driver_headers = {'Authorization': f'Bearer {registered_driver["token"]}'}
+    accept_response = client.post(f'/api/rides/{ride_id}/accept', headers=driver_headers)
+    assert accept_response.status_code == 200
+    json_data = accept_response.get_json()
+    assert json_data['message'] == "Ride accepted successfully"
+    assert json_data['ride']['status'] == "accepted"
+    assert json_data['ride']['driver_id'] == registered_driver['id']
+
+    # Verify passenger can also see the update
+    get_ride_resp = client.get(f'/api/rides/{ride_id}', headers=passenger_headers)
+    assert get_ride_resp.get_json()['driver_id'] == registered_driver['id']
+    assert get_ride_resp.get_json()['status'] == 'accepted'
+
+
+def test_accept_ride_by_passenger_fails(client, registered_user):
+    """Test that a passenger cannot accept a ride."""
+    passenger_headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    ride_payload = {"pickup_location": "A", "dropoff_location": "B"}
+    post_response = client.post('/api/rides/request', headers=passenger_headers, json=ride_payload)
+    ride_id = post_response.get_json()['ride']['id']
+
+    accept_response = client.post(f'/api/rides/{ride_id}/accept', headers=passenger_headers)
+    assert accept_response.status_code == 403
+    assert "Only drivers can accept rides" in accept_response.get_json()['error']
+
+def test_accept_already_accepted_ride_fails(client, registered_user, registered_driver):
+    """Test accepting a ride that is already accepted by another driver."""
+    # Passenger requests
+    passenger_headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    ride_payload = {"pickup_location": "X", "dropoff_location": "Y"}
+    post_response = client.post('/api/rides/request', headers=passenger_headers, json=ride_payload)
+    ride_id = post_response.get_json()['ride']['id']
+
+    # First driver accepts
+    driver1_headers = {'Authorization': f'Bearer {registered_driver["token"]}'}
+    client.post(f'/api/rides/{ride_id}/accept', headers=driver1_headers)
+
+    # Second driver (need another fixture or register another driver)
+    other_driver_data = {"name": "Driver Two", "email": "driver2@example.com", "password": "pwd", "user_type": "driver"}
+    client.post('/auth/register', json=other_driver_data)
+    login_resp = client.post('/auth/login', json={"email": "driver2@example.com", "password": "pwd"})
+    other_driver_token = login_resp.get_json()['access_token']
+    driver2_headers = {'Authorization': f'Bearer {other_driver_token}'}
+
+    accept_response = client.post(f'/api/rides/{ride_id}/accept', headers=driver2_headers)
+    assert accept_response.status_code == 409 # Conflict
+
+def test_update_ride_status_driver_success(client, registered_user, registered_driver):
+    """Test driver successfully updating ride status."""
+    passenger_headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    ride_payload = {"pickup_location": "Start", "dropoff_location": "Finish"}
+    post_response = client.post('/api/rides/request', headers=passenger_headers, json=ride_payload)
+    ride_id = post_response.get_json()['ride']['id']
+
+    driver_headers = {'Authorization': f'Bearer {registered_driver["token"]}'}
+    client.post(f'/api/rides/{ride_id}/accept', headers=driver_headers) # Driver accepts
+
+    # Driver updates status
+    status_payload = {"status": "en_route_pickup"}
+    update_response = client.put(f'/api/rides/{ride_id}/status', headers=driver_headers, json=status_payload)
+    assert update_response.status_code == 200
+    assert update_response.get_json()['ride']['status'] == "en_route_pickup"
+
+    status_payload = {"status": "arrived_pickup"}
+    update_response = client.put(f'/api/rides/{ride_id}/status', headers=driver_headers, json=status_payload)
+    assert update_response.status_code == 200
+
+    status_payload = {"status": "started"}
+    update_response = client.put(f'/api/rides/{ride_id}/status', headers=driver_headers, json=status_payload)
+    assert update_response.status_code == 200
+
+    status_payload = {"status": "completed"}
+    update_response = client.put(f'/api/rides/{ride_id}/status', headers=driver_headers, json=status_payload)
+    assert update_response.status_code == 200
+    assert update_response.get_json()['ride']['status'] == "completed"
+    assert update_response.get_json()['ride']['fare'] is not None
+
+
+def test_update_ride_status_passenger_cancel_success(client, registered_user, registered_driver):
+    """Test passenger successfully cancelling a ride."""
+    passenger_headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    ride_payload = {"pickup_location": "Uptown", "dropoff_location": "Downtown"}
+    post_response = client.post('/api/rides/request', headers=passenger_headers, json=ride_payload)
+    ride_id = post_response.get_json()['ride']['id']
+
+    # Passenger cancels before driver accepts
+    status_payload = {"status": "cancelled"}
+    update_response = client.put(f'/api/rides/{ride_id}/status', headers=passenger_headers, json=status_payload)
+    assert update_response.status_code == 200
+    assert update_response.get_json()['ride']['status'] == "cancelled"
+
+    # New ride for testing cancellation after driver accepts
+    post_response_2 = client.post('/api/rides/request', headers=passenger_headers, json=ride_payload) # Renamed to avoid conflict
+    ride_id_2 = post_response_2.get_json()['ride']['id']
+    driver_headers = {'Authorization': f'Bearer {registered_driver["token"]}'}
+    client.post(f'/api/rides/{ride_id_2}/accept', headers=driver_headers) # Driver accepts
+
+    update_response_2 = client.put(f'/api/rides/{ride_id_2}/status', headers=passenger_headers, json=status_payload)
+    assert update_response_2.status_code == 200
+    assert update_response_2.get_json()['ride']['status'] == "cancelled"
+
+
+def test_update_ride_status_invalid_transition(client, registered_user, registered_driver):
+    """Test invalid status transition by driver."""
+    passenger_headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    post_response = client.post('/api/rides/request', headers=passenger_headers, json={"pickup_location":"A","dropoff_location":"B"})
+    ride_id = post_response.get_json()['ride']['id']
+
+    driver_headers = {'Authorization': f'Bearer {registered_driver["token"]}'}
+    # Ride is 'pending', driver tries to set to 'started' (invalid without accepting first)
+    status_payload = {"status": "started"}
+    update_response = client.put(f'/api/rides/{ride_id}/status', headers=driver_headers, json=status_payload)
+    assert update_response.status_code == 403
+
+
+def test_get_nearby_drivers_mocked(client, registered_user, registered_driver):
+    """Test getting mocked nearby drivers."""
+    # Ensure registered_driver is actually created by calling the fixture
+    # The registered_driver fixture already handles registration and login.
+    # We need its ID for assertion.
+    driver_id = registered_driver['id']
+
+    headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    response = client.get('/api/drivers/nearby', headers=headers)
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert "available_drivers" in json_data
+    # Check if the registered_driver (who is not on a ride) is in the list
+    found_driver = any(d['id'] == driver_id for d in json_data['available_drivers'])
+    assert found_driver == True
+
+
+def test_estimate_fare_mocked(client, registered_user):
+    """Test getting mocked fare estimation."""
+    headers = {'Authorization': f'Bearer {registered_user["token"]}'}
+    fare_payload = {"pickup_location": "Long Street", "dropoff_location": "Short Avenue"}
+    response = client.post('/api/rides/estimate_fare', headers=headers, json=fare_payload)
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert "estimated_fare_rand" in json_data
+    assert "currency" in json_data and json_data['currency'] == "ZAR"


### PR DESCRIPTION
I've implemented the initial backend for the PacknRide application using Flask. This phase includes:
- User registration (passenger/driver) and JWT-based login.
- Core ride-hailing features:
    - Requesting a ride (passenger).
    - Accepting a ride (driver).
    - Updating ride status.
    - Viewing ride details.
    - Mocked endpoints for nearby drivers and fare estimation.
- In-memory data storage for users and rides.
- Basic error handling and input validation.
- Initial API documentation in README.md.
- Pytest test suite for authentication and ride-hailing endpoints. (Note: I was not able to automatically execute the tests due to getcwd errors affecting pip and pytest.)

The project structure is organized with Blueprints for auth and main API routes, configuration management, and utility functions.